### PR TITLE
Hook in before LXC providers as well as VirtualBox

### DIFF
--- a/lib/vagrant-software-bridge/plugin.rb
+++ b/lib/vagrant-software-bridge/plugin.rb
@@ -15,8 +15,16 @@ module VagrantPlugins
         # configuration middleware) do the actual network configuration on the
         # way up the middleware stack. Therefore, this ensures that we will
         # configure the bridges after the rest of the interfaces.
+
+        # Hook in before VirtualBox provider
         hook.before(VagrantPlugins::ProviderVirtualBox::Action::Network,
                     Action)
+
+        if Vagrant.has_plugin?("vagrant-lxc")
+          require "vagrant-lxc/action"
+          # Hook in before LXC provider
+          hook.before(Vagrant::LXC::Action::PrivateNetworks, Action)
+        end
       end
 
       config "software_bridge" do

--- a/lib/vagrant-software-bridge/version.rb
+++ b/lib/vagrant-software-bridge/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module SoftwareBridge
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
**Description:** Add support for vagrant-lxc to this plugin

**Testing:** Use the plugin in an environment that uses the VirtualBox provider, and one that uses the vagrant-lxc provider. Make sure both work as expected
